### PR TITLE
Replace "times smaller" with "1/x"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -533,7 +533,7 @@ function calculateSaves(post) {
     if (post.webmSize)
         post.webmSave = (post.gifSize / post.webmSize);
     if (!PROD) log(`Link stats: mp4 size: ${post.mp4Size} (webm: ${post.webmSize});
-         that is ${post.mp4Save} times smaller (webm: ${post.webmSave})`);
+         that is 1/${post.mp4Save} times (webm: ${post.webmSave})`);
 }
 
 function toFixedFixed(num, decimals = 2) {

--- a/src/json/config.json
+++ b/src/json/config.json
@@ -18,20 +18,20 @@
     ],
     "textParts": {
       "default": {
-        "sizetext": "This mp4 version is {{mp4sizecomp}} times smaller than the gif ({{gifsize}} vs {{mp4size}}).  \n",
-        "webmsizetext": "The webm version is even {{webmsizecomp}} times smaller ({{webmsize}}).  \n",
+        "sizetext": "This mp4 version is 1/{{mp4sizecomp}} the size of the gif ({{gifsize}} vs {{mp4size}}).  \n",
+        "webmsizetext": "The webm version is 1/{{webmsizecomp}} the size ({{webmsize}}).  \n",
         "mp4biggertext": "This mp4 version is bigger than the gif (GIF: {{gifsize}}, MP4: {{mp4size}}) but it also (probably) has a higher quality and frame rate.  \n",
         "gfycatbiggertext": "Since it is hosted on gfycat the appropriate file format (mp4, webm, big, small) automatically gets chosen according to your specs.  \n"
       },
       "mildlyinfuriating": {
-        "sizetext": "This mp4 verion is {{mp4sizecomp}} times smller than the gif ({{gifsize}} vs {{mp4size}}).  \n",
-        "webmsizetext": "The webm version is evn {{webmsizecomp}} time smaller ({{webmsize}}).  \n",
+        "sizetext": "This mp4 verion is 1/{{mp4sizecomp}} the size of the gif ({{gifsize}} vs {{mp4size}}).  \n",
+        "webmsizetext": "The webm version is 1/{{webmsizecomp}} the size ({{webmsize}}).  \n",
         "mp4biggertext": "This mp4 verion is bigger than the gif (GIF: {{gifsize}}, MP4: {{mp4size}}) but it also (prbably) has a higher quality and frme rate.  \n",
         "gfycatbiggertext": "Since it is hsted on gfycat the appropiate file format (mp4, webm, big, small) automatically gets chosen accordig to your specs.  \n"
       },
       "totallynotrobots": {
-        "sizetext": "THIS MP4 VERSION IS {{mp4sizecomp}} TIMES SMALLER THAN THE GIF ({{gifsize}} VS {{mp4size}}).  \n",
-        "webmsizetext": "THE WEBM VERSION IS EVEN {{webmsizecomp}} TIMES SMALLER ({{webmsize}}).  \n",
+        "sizetext": "THIS MP4 VERSION IS 1/{{mp4sizecomp}} THE SIZE OF THE GIF ({{gifsize}} VS {{mp4size}}).  \n",
+        "webmsizetext": "THE WEBM VERSION IS 1/{{webmsizecomp}} THE SIZE ({{webmsize}}).  \n",
         "mp4biggertext": "THIS MP4 VERSION IS BIGGER THAN THE GIF (GIF: {{gifsize}}, MP4: {{mp4size}}) BUT IT ALSO (PROBABLY) HAS A HIGHER QUALITY AND FRAME RATE.  \n",
         "gfycatbiggertext": "SINCE IT IS HOSTED ON GFYCAT THE APPROPRIATE FILE FORMAT (MP4, WEBM, BIG, SMALL) AUTOMATICALLY GETS CHOSEN ACCORDING TO YOUR SPECS.  \n"
       },
@@ -40,7 +40,7 @@
       },
       "PeopleFuckingDying": {
         "sizetext": "THis mp4 VersIOn iS {{mp4sizecomp}} TIMEs SMALLER tHAn THe gif ({{gifsize}} vS {{mp4size}}).  \n",
-        "webmsizetext": "THE WebM VeRSioN Is EVeN {{webmsizecomp}} TimeS SmALLER ({{webmsize}}).  \n",
+        "webmsizetext": "THE WebM VeRSioN Is 1/{{webmsizecomp}} ThE SIze ({{webmsize}}).  \n",
         "mp4biggertext": "thIs MP4 VeRSion IS bigger thAN tHE GIF (GIf: {{gifsize}}, mp4: {{mp4size}}) BUT iT aLso (prObabLy) haS A HIgheR QUALItY anD fraMe ratE.  \n",
         "gfycatbiggertext": "Since IT is HoSTeD oN gFyCaT tHe APproPRiAte FILe Format (mp4, WebM, biG, smALL) aUTomAtIcALLy Gets CHoseN AccoRDInG to your SPecs.  \n"
       }


### PR DESCRIPTION
The phrase "times smaller" was used throughout messages posted
to reddit by this script. This means we could have phrases like
"1 times smaller", which could mean 0-bytes or the same size,
depending on whether someone thinks "smaller" means to subtract
or is an unnecessary decorative word.

"1MB smaller" implies subtraction of 1MB from the original size,
and "1% smaller" implies subtraction of 1/100 from the original size.
"1% times smaller", as used in this script, implies neither.

The script's output describes multiplication by 1/x, or division by x.

Every post by this bot is a misleading example, confusing our children.
Replace template sentences with non-ambiguous terms, to avoid
perpetuating confusion.

For examples of confusion, see:
 https://english.stackexchange.com/a/114395
 https://english.stackexchange.com/a/114408